### PR TITLE
Fix version conflicts caused by PR#19

### DIFF
--- a/src/CSharpRecordsAnalyzer.Test/CSharpRecordsAnalyzer.Test.csproj
+++ b/src/CSharpRecordsAnalyzer.Test/CSharpRecordsAnalyzer.Test.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.3">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />

--- a/src/CSharpRecordsAnalyzer/CSharpRecordsAnalyzer.csproj
+++ b/src/CSharpRecordsAnalyzer/CSharpRecordsAnalyzer.csproj
@@ -34,8 +34,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.1.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
I encountered a similar dependency hell issue when Bump Microsoft.CodeAnalysis.CSharp.Workspaces from 3.1.0 to 3.10.0 in /src/CSharpRecordsAnalyzer. [(PR#19)](https://github.com/dsschneidermann/CSharpRecordsAnalyzer/pull/19).
Hope this fix can help you.

Best regards,
sucrose